### PR TITLE
Manage multiple paths for packages entry

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,20 +8,26 @@ const path = require('path')
 const interfaceVersion = 2
 
 function resolve(importpath, caller, config = {}) {
-  const packages = config.packages
+  const { packages } = config
   const basename = pkgbasename(importpath)
   const index = new Map()
 
   // Populate the index with the package names this monorepo contains
-  fs
-    .readdirSync(packages)
-    .map(filename => path.resolve(packages, filename))
-    .filter(filename => fs.statSync(filename).isDirectory())
-    .forEach(filename => {
-      // eslint-disable-next-line global-require
-      const pkg = require(path.resolve(filename, 'package'))
-      index.set(pkg.name, filename)
-    })
+  const packagesDirectories = Array.isArray(packages)
+    ? packages
+    : [packages]
+
+  packagesDirectories.forEach(packagesDir => {
+    fs
+      .readdirSync(packagesDir)
+      .map(filename => path.resolve(packagesDir, filename))
+      .filter(filename => fs.statSync(filename).isDirectory())
+      .forEach(filename => {
+        // eslint-disable-next-line global-require
+        const { name } = require(path.resolve(filename, 'package'))
+        index.set(name, filename)
+      })
+  })
 
   return index.has(basename)
     ? { found: true, path: index.get(basename) }


### PR DESCRIPTION
Hello,

According to the documentation of lerna, packages entry can be an array of globs.

ref: https://github.com/lerna/lerna#lernajson

I update your code to manage an array of paths in addition to manage a unique path :)

See you!