### PR TITLE
handle stray folder

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,9 @@ function resolve(importpath, caller, config = {}) {
           const pkg = require(path.resolve(filename, 'package'))
 
           index.set(pkg.name, filename)
-        } catch(err) {}
+        } catch (err) {
+          // package.json doesn't exist, do nothing
+        }
       })
   })
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,10 +21,12 @@ function resolve(importpath, caller, config = {}) {
       .map(filename => path.resolve(directory, filename))
       .filter(filename => fs.statSync(filename).isDirectory())
       .forEach(filename => {
-      // eslint-disable-next-line global-require
-        const pkg = require(path.resolve(filename, 'package'))
+        try {
+          // eslint-disable-next-line global-require
+          const pkg = require(path.resolve(filename, 'package'))
 
-        index.set(pkg.name, filename)
+          index.set(pkg.name, filename)
+        } catch(err) {}
       })
   })
 


### PR DESCRIPTION
1. I have a new subpackage in branch `a`
2. I switch to branch `b`
3. the files from branch `a` go away, but the folders stay around
4. `eslint-import-resolver-lerna` errors while trying to resolve the `package.json` of the left over folder

![Screen Shot 2019-07-16 at 5 24 53 PM](https://user-images.githubusercontent.com/1192452/61339531-fc665580-a7f2-11e9-8b42-cd7046f0857c.png)

Solution:

Wrap `require.resolve` in a try/catch and ignore the error.
