### PR TITLE
Correctly resolve to main entry of package

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -23,8 +23,14 @@ function resolve(importpath, caller, config = {}) {
       .forEach(filename => {
       // eslint-disable-next-line global-require
         const pkg = require(path.resolve(filename, 'package'))
-
-        index.set(pkg.name, filename)
+        let resolvedFile;
+        try {
+          resolvedFile = require.resolve(filename);
+        } catch (error) {
+          resolvedFile = filename;
+        }
+      
+        index.set(pkg.name, resolvedFile);
       })
   })
 


### PR DESCRIPTION
Currently the resolver resolves to the package directory. This leads to the rule `import/extensions` complain about missing file extension. Instead the resolver should resolve the same way nodejs does it: either the `main` field in `package.json` or `package-name/index.js`.

If it cannot resolve either we keep the current behaviour.

This is similar how the node resolver does it: https://github.com/benmosher/eslint-plugin-import/blob/master/resolvers/node/index.js#L18 Although they use the `resolve` package, but I didn't see a reason why it should be used over `require.resolve`, but could change that.

Let me know what you think.

Example:

Before this change the result is 
```
{
 found: true, path: '/path/to/project/packages/subrepo'
}
```

After (assuming `packages/subrepo/package.json` has `"main": "lib/index.js"`):
```
{
 found: true, path: '/path/to/project/packages/subrepo/lib/index.js'
}
```