### PR TITLE
Feature: Add ignore flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ This plugin will look in your _packages_ directory and generate a list of all th
 
 ## Usage
 
-This resolver accepts only one configuration option: `packages` (string or array of strings, required) which must be an absolute path to Lerna's _packages_ directory or an array of such absolute paths.
+This resolver accepts two configuration options:
+
+`packages` (string or array of strings, required) which must be an absolute path to Lerna's _packages_ directory or an array of such absolute paths.
 
 ```js
 // .eslintrc.js
@@ -33,6 +35,24 @@ module.exports = {
     'import/resolver': {
       'eslint-import-resolver-lerna': {
         packages: path.resolve(__dirname, 'src/packages')
+      }
+    }
+  }
+}
+```
+
+`ignore` (array of string regex) which will be used to ignore folders that isn't a package.
+
+```js
+// .eslintrc.js
+const path = require('path')
+
+module.exports = {
+  settings: {
+    'import/resolver': {
+      'eslint-import-resolver-lerna': {
+        packages: path.resolve(__dirname, 'src/packages'),
+        ignore: ['(helpers|setups)']
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ const path = require('path')
 const interfaceVersion = 2
 
 function resolve(importpath, caller, config = {}) {
+  const ignore = config.ignore || []
   const directories = Array.isArray(config.packages)
     ? config.packages
     : [config.packages]
@@ -19,7 +20,11 @@ function resolve(importpath, caller, config = {}) {
     fs
       .readdirSync(directory)
       .map(filename => path.resolve(directory, filename))
-      .filter(filename => fs.statSync(filename).isDirectory())
+      .filter(filename => {
+        const isDirectory = fs.statSync(filename).isDirectory()
+        const notIgnored = ignore.every(regex => !new RegExp(regex, 'ug').test(filename))
+        return isDirectory && notIgnored
+      })
       .forEach(filename => {
       // eslint-disable-next-line global-require
         const pkg = require(path.resolve(filename, 'package'))


### PR DESCRIPTION
Some cases we have some folder inside `packages` that's not an package.

In these cases the resolver throws an exception, since it doesn't have an `package.json`.

This PR adds an ignore flag to avoid this scenario. 