### PR TITLE
Wrap `require` in `try...catch` block

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,9 +22,11 @@ function resolve(importpath, caller, config = {}) {
       .filter(filename => fs.statSync(filename).isDirectory())
       .forEach(filename => {
       // eslint-disable-next-line global-require
-        const pkg = require(path.resolve(filename, 'package'))
+      	try {
+	        const pkg = require(path.resolve(filename, 'package'))
 
-        index.set(pkg.name, filename)
+	        index.set(pkg.name, filename)
+				} catch () {}
       })
   })
 


### PR DESCRIPTION
Lerna doesn't dictate that you *have* to have a flat directory structure, nor that every directory within a defined "packages" directory has to be a package. Wrapping the require attempt in a `try...catch` block allows only directories with `package.json` files to be added to `index` for checking later on.